### PR TITLE
Handle policy with custom symbol list

### DIFF
--- a/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
+++ b/src/ui/wxWidgets/AddEditPropSheetDlg.cpp
@@ -2141,9 +2141,9 @@ uint32_t AddEditPropSheetDlg::GetChanges() const
       }
     }
   }
-  // policy
+  // policy options string (symbol list is checked above)
   {
-    PWPolicy oldPWP;
+    StringX oldPWP, newPWP;
     // get item's effective policy:
     const StringX oldPolName = m_Item.GetPolicyName();
     if (oldPolName.empty()) { // either item-specific or default:
@@ -2151,14 +2151,27 @@ uint32_t AddEditPropSheetDlg::GetChanges() const
         oldPWP = PWSprefs::GetInstance()->GetDefaultPolicy();
       }
       else {
-        m_Item.GetPWPolicy(oldPWP);
+        oldPWP = m_Item.GetPWPolicy();
       }
     }
     else {
-      m_Core.GetPolicyFromName(oldPolName, oldPWP);
+      PWPolicy pol;
+      m_Core.GetPolicyFromName(oldPolName, pol);
+      oldPWP = pol;  // convert to StringX
     }
-    // now check with dbox's effective policy:
-    if (oldPWP != GetSelectedPWPolicy()) {
+
+    // Now check with dbox's effective policy:
+    // If using a defined policy but the name is empty, it will cause
+    // an assertion in GetSelectedPWPolicy() - GetPolicyFromName().
+    // This should only happen if an incomplete policy edit is canceled.
+    if (m_PasswordPolicyUseDatabaseCtrl->GetValue() && m_PasswordPolicyNamesCtrl->GetValue().empty()) {
+      newPWP = L"";  // force the compare false
+    }
+    else {
+      newPWP = GetSelectedPWPolicy();
+    }
+
+    if (oldPWP != newPWP) {
       changes |= Changes::Policy;
     }
   }


### PR DESCRIPTION
When using a custom PW policy symbol list, the policy comparison would always say the dialog content has changed when an entry is opened and canceled.