### PR TITLE
[macOS] Typo in file type definition

### DIFF
--- a/Xcode/pwsafe-template.plist
+++ b/Xcode/pwsafe-template.plist
@@ -63,7 +63,7 @@
 			<key>UTTypeConformsTo</key>
 			<array>
 				<string>public.data</string>
-				<string>public.contents</string>
+				<string>public.content</string>
 			</array>
 			<key>UTTypeDescription</key>
 			<string>Password Safe Database</string>
@@ -87,7 +87,7 @@
 			<key>UTTypeConformsTo</key>
 			<array>
 				<string>public.data</string>
-				<string>public.contents</string>
+				<string>public.content</string>
 			</array>
 			<key>UTTypeDescription</key>
 			<string>Password Safe Backup</string>


### PR DESCRIPTION
I don't think it caused any issues, but now it's "more correct".