### PR TITLE
[wx 3.3.x] Assertion in YubiCfgDlg.cpp

### DIFF
--- a/src/ui/wxWidgets/YubiCfgDlg.cpp
+++ b/src/ui/wxWidgets/YubiCfgDlg.cpp
@@ -350,7 +350,8 @@ void YubiCfgDlg::yubiInserted(void)
     m_yksk = wxEmptyString;
   ReadYubiSN();
   dynamic_cast<wxTextCtrl*>(FindWindow(ID_YK_SERNUM))->ChangeValue(m_yksernum);
-  Validate(); TransferDataToWindow();
+  Validate();
+  TransferDataToWindow();
 }
 
 void YubiCfgDlg::yubiRemoved(void)

--- a/src/ui/wxWidgets/YubiCfgDlg.cpp
+++ b/src/ui/wxWidgets/YubiCfgDlg.cpp
@@ -349,7 +349,7 @@ void YubiCfgDlg::yubiInserted(void)
   } else
     m_yksk = wxEmptyString;
   ReadYubiSN();
-  dynamic_cast<wxTextCtrl*>(FindWindow(ID_YK_SERNUM))->SetValue(m_yksernum);
+  dynamic_cast<wxTextCtrl*>(FindWindow(ID_YK_SERNUM))->ChangeValue(m_yksernum);
   Validate(); TransferDataToWindow();
 }
 

--- a/src/ui/wxWidgets/YubiCfgDlg.cpp
+++ b/src/ui/wxWidgets/YubiCfgDlg.cpp
@@ -349,7 +349,7 @@ void YubiCfgDlg::yubiInserted(void)
   } else
     m_yksk = wxEmptyString;
   ReadYubiSN();
-  FindWindow(ID_YK_SERNUM)->SetLabel(m_yksernum);
+  dynamic_cast<wxTextCtrl*>(FindWindow(ID_YK_SERNUM))->SetValue(m_yksernum);
   Validate(); TransferDataToWindow();
 }
 


### PR DESCRIPTION
With a YibiKey inserted, select menu Manage->YibiKey...
I get the attached assert when built with wx 3.3.3.1 (does not happen with wx 3.2.x)

The changelog for wx 3.3.x says this under the heading "INCOMPATIBLE CHANGES SINCE 3.2.x:"
- Calling wxTextCtrl::SetLabel() now consistently does nothing and asserts
under all platforms instead of behaving as SetValue() under MSW and doing
nothing elsewhere.

I have a feeling we may find more of these, but I haven't yet :-)

<img width="692" height="329" alt="Screenshot 2026-08-27 at 12 58 25 PM" src="https://github.com/user-attachments/assets/40fc5f7a-043e-4f9a-8d9d-7077c8051712" />

Found and fixed with a debug build on :
macOS M1Max 15.7.9 Sequoia, Xcode 16.4, wx 3.3.3.1
